### PR TITLE
P2/630P2 Issue#27 - Cache roleNames in PModItem

### DIFF
--- a/src/models/PModItem.cpp
+++ b/src/models/PModItem.cpp
@@ -41,6 +41,8 @@ PModItem::PModItem(QObject *parent)
 
     // Instance
     m_ui_component = nullptr;
+
+    initializeRoleNames()
 }
 
 PModItem::PModItem(
@@ -120,6 +122,7 @@ PModItem::PModItem(
     m_ui_component = nullptr;
     m_selected = false;
     m_listed = true;
+    initializeRoleNames()
 }
 
 PModItem::PModItem(QObject *parent, const QSqlQuery &query) : QObject(parent)
@@ -158,6 +161,7 @@ PModItem::PModItem(QObject *parent, const QSqlQuery &query) : QObject(parent)
     // Graphics properties
     setIconPaths(query.value("icon_paths").toString().split(", "));
 
+    initializeRoleNames()
 }
 
 // ----------------------------------------------- Mod properties
@@ -617,10 +621,8 @@ void PModItem::setData(int role, const QVariant &value)
     }
 }
 
-QHash<int, QByteArray> PModItem::roleNames()
+void PModItem::initializeRoleNames()
 {
-    QHash<int, QByteArray> roles;
-
     // Mod properties
     roles[ModTitleRole] = "title";
     roles[ModAuthorRole] = "authors";
@@ -656,7 +658,10 @@ QHash<int, QByteArray> PModItem::roleNames()
 
     // Graphics properties
     roles[ModIconPathsRole] = "iconpaths";
+}
 
-    return roles;
+
+QHash<int, QByteArray> PModItem::roleNames() {
+  return roles;
 }
 

--- a/src/models/PModItem.h
+++ b/src/models/PModItem.h
@@ -236,6 +236,10 @@ signals:
     void collectionIdChanged();
 
 private:
+    // Cached rolenames
+    QHash<int, QByteArray> roles;
+    void initializeRoleNames();
+
     // Mod properties
     int m_index;
     QString m_title;


### PR DESCRIPTION
Closes #27

Added roles as a private member variable.

Added a role name initialization function which is called in all constructors of pmoditem.

`roleNames` function now simply returns the already initialized mapping of roles to names.

It may be worth changing `roleNames()` to return a constant reference, but that seemed out-of-scope for this issue, as it may require further reworking of functions that call `roleNames`, rather than simply caching it on instantiation which has minimal impact beyond improving efficiency.