### PR TITLE
630:P3 Closes #56 Open-Closed Violation in PFile virtual filesystem selection → Factory Method

### DIFF
--- a/src/filesystem/PFile.cpp
+++ b/src/filesystem/PFile.cpp
@@ -9,7 +9,7 @@ PFile::PFile(QObject *parent, const QString &filePath, FileType type)
 // Create a virtual filesystem object
 std::unique_ptr<IVirtualFilesystem> PFile::createFilesystem(const QString &path, FileType type) const
 {
-  return PIFilesystemFactory::createFilesystem(path, type);
+  return IVirtualFilesystemFactory::createFilesystem(path, type);
 }
 
 QSharedPointer<PFileData> PFile::read(const QString &relFilePath) {

--- a/src/filesystem/PFile.cpp
+++ b/src/filesystem/PFile.cpp
@@ -9,7 +9,7 @@ PFile::PFile(QObject *parent, const QString &filePath, FileType type)
 // Create a virtual filesystem object
 std::unique_ptr<IVirtualFilesystem> PFile::createFilesystem(const QString &path, FileType type) const
 {
-  return PIVirtualFilesystemFactory::createFilesystem(path, type);
+  return PIFilesystemFactory::createFilesystem(path, type);
 }
 
 QSharedPointer<PFileData> PFile::read(const QString &relFilePath) {

--- a/src/filesystem/PFile.cpp
+++ b/src/filesystem/PFile.cpp
@@ -9,13 +9,7 @@ PFile::PFile(QObject *parent, const QString &filePath, FileType type)
 // Create a virtual filesystem object
 std::unique_ptr<IVirtualFilesystem> PFile::createFilesystem(const QString &path, FileType type) const
 {
-    if (type == FileType::Zip) {
-        qDebug() << "Creating PZip filesystem for path:" << path;
-        return std::make_unique<PZip>(path);
-    } else {
-        qDebug() << "Creating PFileSystem filesystem for path:" << path;
-        return std::make_unique<PFileSystem>();
-    }
+  return PIVirtualFilesystemFactory::createFilesystem(path, type);
 }
 
 QSharedPointer<PFileData> PFile::read(const QString &relFilePath) {

--- a/src/filesystem/PFile.h
+++ b/src/filesystem/PFile.h
@@ -23,15 +23,16 @@ enum FileType {
 /**
  * @brief Factory to delegate construction of IVirtualFilesystems for PFile::createFilesystem
  */
-class PIVirtualFilesystemFactory {
+class PIFilesystemFactory {
 public:
-  virtual ~PIVirtualFilesystemFactory() {}
+  PIFilesystemFactory() = delete;
 
-  virtual std::unique_ptr<IVirtualFilesystem> createFilesystem(const QString &path, FileType type) const {
-    if (type == FileType::Zip) {
+  static std::unique_ptr<IVirtualFilesystem> createFilesystem(const QString &path, FileType type) const {
+    switch (type) {
+      case FileType::Zip:
         qDebug() << "Creating PZip filesystem for path:" << path;
         return std::make_unique<PZip>(path);
-    } else {
+      default:
         qDebug() << "Creating PFileSystem filesystem for path:" << path;
         return std::make_unique<PFileSystem>();
     }

--- a/src/filesystem/PFile.h
+++ b/src/filesystem/PFile.h
@@ -19,6 +19,26 @@ enum FileType {
     Other
 };
 
+
+/**
+ * @brief Factory to delegate construction of IVirtualFilesystems for PFile::createFilesystem
+ */
+class PIVirtualFilesystemFactory {
+public:
+  virtual ~PIVirtualFilesystemFactory() {}
+
+  virtual std::unique_ptr<IVirtualFilesystem> createFilesystem(const QString &path, FileType type) const {
+    if (type == FileType::Zip) {
+        qDebug() << "Creating PZip filesystem for path:" << path;
+        return std::make_unique<PZip>(path);
+    } else {
+        qDebug() << "Creating PFileSystem filesystem for path:" << path;
+        return std::make_unique<PFileSystem>();
+    }
+  }
+};
+
+
 class PFile : public QObject {
     Q_OBJECT
 public:

--- a/src/filesystem/PFile.h
+++ b/src/filesystem/PFile.h
@@ -23,11 +23,11 @@ enum FileType {
 /**
  * @brief Factory to delegate construction of IVirtualFilesystems for PFile::createFilesystem
  */
-class PIFilesystemFactory {
+class IVirtualFilesystemFactory {
 public:
-  PIFilesystemFactory() = delete;
+  IVirtualFilesystemFactory() = delete;
 
-  static std::unique_ptr<IVirtualFilesystem> createFilesystem(const QString &path, FileType type) const {
+  static std::unique_ptr<IVirtualFilesystem> createFilesystem(const QString &path, FileType type) {
     switch (type) {
       case FileType::Zip:
         qDebug() << "Creating PZip filesystem for path:" << path;


### PR DESCRIPTION
Closes #56

# Summary of the refactor:

Moved backend selection logic from `PFile::createFilesystem` into a factory.

 
# Mention of the design pattern used:

Factory

# verification notes (tests run, manual steps)

Builds without issue and tests all pass.

# Acceptance criteria met:

* Concrete backend selection is removed from PFile.
* Adding another filesystem backend does not require editing PFile::createFilesystem.
* PFile remains a thin delegator over IVirtualFilesystem.
* Existing zip and filesystem behavior remains unchanged.