### PR TITLE
630:P3 Closes #61 Presentation Leakage into PModItem - Observer

### DIFF
--- a/src/controllers/PModController.cpp
+++ b/src/controllers/PModController.cpp
@@ -143,10 +143,6 @@ bool PModController::setModEnabled(QSharedPointer<PModItem> mod, bool enabled)
     db.updateMod(mod->id(), "enabled", enabled ? "1" : "0");
     db.closeDatabase();
 
-    // qml stuff
-    if (QObject* component = mod->uiComponent()) {
-        component->setProperty("opacity", enabled ? 1.0 : 0.5);
-    }
     mod->setEnabled(enabled);
     mod->setLocation(targetLocation);
 

--- a/src/models/PModItem.cpp
+++ b/src/models/PModItem.cpp
@@ -39,9 +39,6 @@ PModItem::PModItem(QObject *parent)
     m_dependency_id = "";
     m_collection_id = "";
 
-    // Instance
-    m_ui_component = nullptr;
-
     initializeRoleNames();
 }
 
@@ -115,11 +112,9 @@ PModItem::PModItem(
 
     // External properties
     m_dependency_id(depId),
-    m_collection_id(collectionId),
-    m_ui_component(nullptr)
+    m_collection_id(collectionId)
 {
     m_index = 0;
-    m_ui_component = nullptr;
     m_selected = false;
     m_listed = true;
     initializeRoleNames();

--- a/src/models/PModItem.cpp
+++ b/src/models/PModItem.cpp
@@ -487,14 +487,6 @@ void PModItem::setCollectionId(const QString &newCollectionId)
 
 // ------------------------------------------------ Instance
 
-void PModItem::setUIComponent(QObject* item)
-{
-    if (m_ui_component != item) {
-        m_ui_component = item;
-        emit qmlItemChanged();
-    }
-}
-
 QVariant PModItem::getData(int role) const
 {
     switch ((Role) role)

--- a/src/models/PModItem.h
+++ b/src/models/PModItem.h
@@ -184,10 +184,6 @@ public:
     QString collectionId() const;
     void setCollectionId(const QString &collectionId);
 
-    // Instance
-    QObject* uiComponent() const { return m_ui_component; }
-    void setUIComponent(QObject* item);
-
     // Model implementations
     QVariant getData(int role) const;
     static QHash<int, QByteArray> roleNames();

--- a/src/models/PModItem.h
+++ b/src/models/PModItem.h
@@ -47,10 +47,6 @@ class PModItem : public QObject
     Q_PROPERTY(QString dependencyId READ dependencyId WRITE setDependencyId NOTIFY dependencyIdChanged)
     Q_PROPERTY(QString collectionId READ collectionId WRITE setCollectionId NOTIFY collectionIdChanged)
 
-    // Instance
-    Q_PROPERTY(QObject* uiComponent READ uiComponent WRITE setUIComponent NOTIFY qmlItemChanged)
-
-
 public:
     enum Role {
         // Mod properties
@@ -273,9 +269,6 @@ private:
     // External properties
     QString m_dependency_id;
     QString m_collection_id;
-
-    // Instance
-    QObject* m_ui_component = nullptr;
 };
 
 #endif // PMODITEM_H

--- a/src/mods/PModUIController.cpp
+++ b/src/mods/PModUIController.cpp
@@ -248,11 +248,7 @@ void PModUIController::updateOpacity(int index, bool enabled) {
         return;
     }
 
-    if (!mod->uiComponent()) {
-        qDebug() << "Mod UI component is null, cannot update opacity.";
-        return;
-    }
-    mod->uiComponent()->setProperty("opacity", enabled ? 1.0 : 0.9);
+    mod->setEnabled(enabled);
 }
 
 // --------------- Filter and Search ------------------

--- a/ui/modlist/ModItem.qml
+++ b/ui/modlist/ModItem.qml
@@ -22,14 +22,6 @@ Item {
     anchors.fill: parent
     signal selectedMod(var mod)
 
-    Component.onCompleted: {
-        if (modItem.mod) {
-            modItem.mod.uiComponent = modItem            
-        } else {
-            console.log("MODEL OBJECT IS NULL")
-        }
-    }
-
     Pane {
         id: modPane
         anchors.fill: parent
@@ -201,6 +193,7 @@ Item {
                     color: modItem.mod.enabled ? modPane.determineBackgroundColor("#6B8760") : modPane.determineBackgroundColor(modItem.disabledColor)
                     Layout.preferredWidth: 64
                     Layout.fillHeight: true
+                    opacity: enabled ? 1.0 : 0.5
                     
                     Image {
                         id: modIcon


### PR DESCRIPTION
Closes #61

# Summary of the refactor:

Removed `uiComponent` from `PModItem`. Exposed state changes via properties/signals only, and let QML bindings or a dedicated view-model observe and update opacity/presentation.
 
# Mention of the design pattern used:

Observer

# verification notes (tests run, manual steps)

Build still compiles cleanly and tests still pass; UI still observes opacity changes

# Acceptance criteria met:

* `PModItem` no longer stores `QObject*` UI references.
* UI appearance changes are driven by bindings, signals, or view-model state.
* Controllers stop calling `setProperty` on view objects through model entities.
* Current visible enable/disable cues remain unchanged.