### PR TITLE
630:P3 Closes #53 Type-Keys Conditionals in mod categorization → Strategy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ qt_add_executable(appPandaLdr
     # mods
     src/mods/PModUIController.cpp src/mods/PModUIController.h
     src/mods/PModDataAccess.cpp src/mods/PModDataAccess.h
+    src/mods/PModTypeStrategy.h
     src/mods/PModLoader.cpp src/mods/PModLoader.h
     # database
     src/database/PDatabase.cpp src/database/PDatabase.h

--- a/src/mods/PModLoader.cpp
+++ b/src/mods/PModLoader.cpp
@@ -147,27 +147,20 @@ void PModLoader::loadModsFromFile(const QStringList &ztdList)
 // Determine the category of the mod based on the file extension and path
 // Possible categories are: Building, Scenery, Animals, misc, Unknown
 QString PModLoader::determineCategory(const QSharedPointer<PFileData> &fileData) {
+    if (!fileData) { return "Unknown"; }
+
     if (fileData->data.size() == 0) {
         return "Unknown";
     }
 
+    // Extract the file extension from the fileData
     QString ext = fileData->ext;
 
-    if (ext == "ucb") {
-            return "Building";
-    } else if (ext == "ucs") {
-            return "Scenery";
-    } else if (ext == "uca") {
-            return "Animals";
-    } else if (ext == "ai") {
-        QStringList pathParts = fileData->path.split("/");
-        // category is always the first part of the path
-        QString category = pathParts[0];
-        // return proper case for category
-        return category.toUpper().left(1) + category.mid(1).toLower();
-    } else {
-            return "Unknown";
-    }
+    // Instantiate the strategy for this file data
+    auto strategy = ModTypeStrategyFactory::create(ext);
+
+    // Return the strategy using it's corresponding factory
+    return strategy->determineCategory(fileData);
 }
 
 QVector<QSharedPointer<PModItem>> PModLoader::buildCollectionMods(const QVector<QSharedPointer<PFileData>> &entryPoints, const QSharedPointer<PModItem> &mod, const QSharedPointer<PFile> &ztd) {

--- a/src/mods/PModLoader.h
+++ b/src/mods/PModLoader.h
@@ -11,6 +11,7 @@
 #include "PConfigMgr.h"
 #include "PApeFile.h"
 #include "PModDataAccess.h"
+#include "PModTypeStrategy.h"
 
 class PModLoader : public QObject
 {

--- a/src/mods/PModTypeStrategy.h
+++ b/src/mods/PModTypeStrategy.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <QString>
+#include <QSharedPointer>
+
+#include "PFileData.h"
+
+class ModTypeStrategy {
+public:
+    virtual ~ModTypeStrategy() = default;
+
+    virtual QString determineCategory(
+        const QSharedPointer<PFileData>& fileData) const = 0;
+};

--- a/src/mods/PModTypeStrategy.h
+++ b/src/mods/PModTypeStrategy.h
@@ -2,6 +2,8 @@
 
 #include <QString>
 #include <QSharedPointer>
+#include <unordered_map>
+#include <functional>
 
 #include "PFileData.h"
 
@@ -11,4 +13,82 @@ public:
 
     virtual QString determineCategory(
         const QSharedPointer<PFileData>& fileData) const = 0;
+};
+
+class BuildingStrategy : public ModTypeStrategy {
+public:
+    QString determineCategory(
+        const QSharedPointer<PFileData>&) const override
+    {
+        return "Building";
+    }
+};
+
+class SceneryStrategy : public ModTypeStrategy {
+public:
+    QString determineCategory(
+        const QSharedPointer<PFileData>&) const override
+    {
+        return "Scenery";
+    }
+};
+
+class AnimalStrategy : public ModTypeStrategy {
+public:
+    QString determineCategory(
+        const QSharedPointer<PFileData>&) const override
+    {
+        return "Animals";
+    }
+};
+
+class AIStrategy : public ModTypeStrategy {
+public:
+    QString determineCategory(
+        const QSharedPointer<PFileData>& fileData) const override
+    {
+        QStringList pathParts = fileData->path.split("/");
+
+        if (pathParts.isEmpty()) {
+            return "Unknown";
+        }
+
+        QString category = pathParts[0];
+
+        // Proper-case category
+        return category.left(1).toUpper()
+             + category.mid(1).toLower();
+    }
+};
+
+class UnknownStrategy : public ModTypeStrategy {
+public:
+    QString determineCategory(
+        const QSharedPointer<PFileData>&) const override
+    {
+        return "Unknown";
+    }
+};
+
+class ModTypeStrategyFactory {
+public:
+    using Creator = std::function<std::unique_ptr<ModTypeStrategy>()>;
+
+    static std::unique_ptr<ModTypeStrategy> create(const QString& ext)
+    {
+        static const std::unordered_map<QString, Creator> registry = {
+            { "ucb", [] { return std::make_unique<BuildingStrategy>(); } },
+            { "ucs", [] { return std::make_unique<SceneryStrategy>(); } },
+            { "uca", [] { return std::make_unique<AnimalStrategy>(); } },
+            { "ai",  [] { return std::make_unique<AIStrategy>(); } }
+        };
+
+        auto it = registry.find(ext);
+
+        if (it != registry.end()) {
+            return it->second();
+        }
+
+        return std::make_unique<UnknownStrategy>();
+    }
 };


### PR DESCRIPTION
Closes #53 

# Summary of the refactor:

Created a strategy and simple factory to handle category determination of files given their file extensions.

Removed previous implementation that had used in-class type-keyed conditionals.

# Mention of the design pattern used:

Strategy and simple factory.

# Verification notes:

Compiles without error and passes all tests.

# Acceptance criteria met:

* Category-specific behavior no longer depends on repeated if/else chains.
* Adding a new mod type can be done by introducing a new strategy class.
* String category checks are centralized to one resolution step.
* Current categories continue to import with unchanged behavior.